### PR TITLE
Add API for pushing native view controllers

### DIFF
--- a/lib/ios/RNNBridgeManager.h
+++ b/lib/ios/RNNBridgeManager.h
@@ -2,6 +2,8 @@
 #import <React/RCTBridge.h>
 #import "RNNBridgeManagerDelegate.h"
 
+@class RNNBridgeModule;
+
 typedef UIViewController * (^RNNExternalViewCreator)(NSDictionary* props, RCTBridge* bridge);
 
 @interface RNNBridgeManager : NSObject <RCTBridgeDelegate>
@@ -9,6 +11,8 @@ typedef UIViewController * (^RNNExternalViewCreator)(NSDictionary* props, RCTBri
 - (instancetype)initWithJsCodeLocation:(NSURL *)jsCodeLocation launchOptions:(NSDictionary *)launchOptions bridgeManagerDelegate:(id<RNNBridgeManagerDelegate>)delegate mainWindow:(UIWindow *)mainWindow;
 
 - (void)registerExternalComponent:(NSString *)name callback:(RNNExternalViewCreator)callback;
+
+- (RNNBridgeModule *)getBridgeModule;
 
 @property (readonly, nonatomic, strong) RCTBridge *bridge;
 

--- a/lib/ios/RNNBridgeManager.m
+++ b/lib/ios/RNNBridgeManager.m
@@ -28,6 +28,7 @@
 	RNNExternalComponentStore* _store;
 
 	RNNCommandsHandler* _commandsHandler;
+	RNNBridgeModule* _bridgeModule;
 }
 
 - (instancetype)initWithJsCodeLocation:(NSURL *)jsCodeLocation launchOptions:(NSDictionary *)launchOptions bridgeManagerDelegate:(id<RNNBridgeManagerDelegate>)delegate mainWindow:(UIWindow *)mainWindow {
@@ -84,8 +85,16 @@
 	
 	_commandsHandler = [[RNNCommandsHandler alloc] initWithControllerFactory:controllerFactory eventEmitter:eventEmitter stackManager:[RNNNavigationStackManager new] modalManager:[RNNModalManager new] overlayManager:[RNNOverlayManager new] mainWindow:_mainWindow];
 	RNNBridgeModule *bridgeModule = [[RNNBridgeModule alloc] initWithCommandsHandler:_commandsHandler];
+	
+	_bridgeModule = bridgeModule;
 
 	return [@[bridgeModule,eventEmitter] arrayByAddingObjectsFromArray:[self extraModulesFromDelegate]];
+}
+
+# pragma mark - React Native Bridge Module
+
+- (RNNBridgeModule *)getBridgeModule {
+	return _bridgeModule;
 }
 
 # pragma mark - JavaScript & Bridge Notifications

--- a/lib/ios/RNNBridgeModule.h
+++ b/lib/ios/RNNBridgeModule.h
@@ -8,4 +8,6 @@
 
 -(instancetype)initWithCommandsHandler:(RNNCommandsHandler*)commandsHandler;
 
+-(void)pushNativeViewController:(NSString*)componentId viewController:(UIViewController *)viewController;
+
 @end

--- a/lib/ios/RNNBridgeModule.m
+++ b/lib/ios/RNNBridgeModule.m
@@ -17,6 +17,12 @@ RCT_EXPORT_MODULE();
 	return self;
 }
 
+-(void)pushNativeViewController:(NSString*)componentId viewController:(UIViewController *)viewController {
+	// commandId is only used for the sendOnNavigationCommandCompletion event transmitted over the bridge.
+	// Unless we start listening for that event this does not need to change.
+	[_commandsHandler pushNativeViewController:componentId commandId:@"pushNativeViewController" viewController:viewController];
+}
+
 #pragma mark - JS interface
 
 RCT_EXPORT_METHOD(setRoot:(NSString*)commandId layout:(NSDictionary*)layout resolver:(RCTPromiseResolveBlock)resolve rejecter:(RCTPromiseRejectBlock)reject) {

--- a/lib/ios/RNNCommandsHandler.h
+++ b/lib/ios/RNNCommandsHandler.h
@@ -20,6 +20,8 @@
 
 - (void)push:(NSString*)componentId commandId:(NSString*)commandId layout:(NSDictionary*)layout completion:(RNNTransitionCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection;
 
+- (void)pushNativeViewController:(NSString*)componentId commandId:(NSString*)commandId viewController:(UIViewController*)viewController;
+
 - (void)pop:(NSString*)componentId commandId:(NSString*)commandId mergeOptions:(NSDictionary*)options completion:(RNNTransitionCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection;
 
 - (void)popTo:(NSString*)componentId commandId:(NSString*)commandId mergeOptions:(NSDictionary*)options completion:(RNNTransitionCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection;

--- a/lib/ios/RNNCommandsHandler.m
+++ b/lib/ios/RNNCommandsHandler.m
@@ -168,6 +168,17 @@ static NSString* const setDefaultOptions	= @"setDefaultOptions";
 	}
 }
 
+- (void)pushNativeViewController:(NSString*)componentId commandId:(NSString*)commandId viewController:(UIViewController*)viewController {
+	[self assertReady];
+	
+	UIViewController *fromVC = [RNNLayoutManager findComponentForId:componentId];
+	RCTExecuteOnMainQueue(^{
+		[_stackManager push:viewController onTop:fromVC animated:YES animationDelegate:nil completion:^{
+			[_eventEmitter sendOnNavigationCommandCompletion:push commandId:commandId params:@{@"componentId": componentId}];
+		} rejection:nil];
+	});
+}
+
 - (void)setStackRoot:(NSString*)componentId commandId:(NSString*)commandId children:(NSArray*)children completion:(RNNTransitionCompletionBlock)completion rejection:(RCTPromiseRejectBlock)rejection {
 	[self assertReady];
 	

--- a/lib/ios/RNNExternalComponentStore.h
+++ b/lib/ios/RNNExternalComponentStore.h
@@ -4,6 +4,8 @@
 #import "ReactNativeNavigation.h"
 #import "RNNLayoutInfo.h"
 
+typedef UIViewController * (^RNNExternalViewCreator)(NSDictionary* props, RCTBridge* bridge);
+
 @interface RNNExternalComponentStore : NSObject
 
 - (void)registerExternalComponent:(NSString *)name callback:(RNNExternalViewCreator)callback;

--- a/lib/ios/ReactNativeNavigation.h
+++ b/lib/ios/ReactNativeNavigation.h
@@ -3,6 +3,7 @@
 #import <React/RCTBridge.h>
 #import <React/RCTUIManager.h>
 #import "RNNBridgeManagerDelegate.h"
+#import "RNNBridgeManager.h"
 
 typedef UIViewController * (^RNNExternalViewCreator)(NSDictionary* props, RCTBridge* bridge);
 
@@ -17,5 +18,7 @@ typedef UIViewController * (^RNNExternalViewCreator)(NSDictionary* props, RCTBri
 + (UIViewController *)findViewController:(NSString *)componentId;
 
 + (RCTBridge *)getBridge;
+
++ (RNNBridgeManager *)getBridgeManager;
 
 @end

--- a/lib/ios/ReactNativeNavigation.m
+++ b/lib/ios/ReactNativeNavigation.m
@@ -36,6 +36,10 @@
     return [RNNLayoutManager findComponentForId:componentId];
 }
 
++ (RNNBridgeManager *)getBridgeManager {
+	return [ReactNativeNavigation sharedInstance].bridgeManager;
+}
+
 # pragma mark - instance
 
 + (instancetype) sharedInstance {


### PR DESCRIPTION
**Changes**
- Add `pushNativeViewController` method to `RNNCommandsHandler` to expose pushing native View Controllers
- Add getters for `RNNBridgeModule` and `BridgeManager` to be able to access `pushNativeViewController` externally from Swift
- Add `typedef`s, `class` declarations, and `import`s to be able to compile new methods that are exposed, since adding the above changes the compilation order